### PR TITLE
Update Pluggy to Version 1.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
     - pluggy
   requires:
     - pip
+    - python <3.10
   command:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pluggy" %}
-{% set version = "0.13.1" %}
-{% set sha256 = "15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0" %}
+{% set version = "1.0.0" %}
+{% set sha256 = "4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159" %}
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,17 +17,22 @@ build:
 
 requirements:
   host:
-    - python
+    - python 
     - pip
     - setuptools_scm
+    - wheel
 
   run:
-    - python
+    - python >=3.6
     - importlib_metadata >=0.12  # [py<38]
 
 test:
   imports:
     - pluggy
+  requires:
+    - pip
+  command:
+    - pip check
 
 about:
   home: https://github.com/pytest-dev/pluggy


### PR DESCRIPTION
1. check the upstream

2. check the pinnings
https://github.com/pytest-dev/pluggy/blob/1.0.0/tox.ini
https://github.com/pytest-dev/pluggy/blob/1.0.0/setup.py
https://github.com/pytest-dev/pluggy/blob/1.0.0/setup.cfg
https://github.com/pytest-dev/pluggy/blob/1.0.0/pyproject.toml

have to be careful with over pinning the package otherwise the package fails to build

3. check changelogs
https://github.com/pytest-dev/pluggy/blob/1.0.0/CHANGELOG.rst

There are some important deprecations and removals specified on the ChangeLog

Deprecations and Removals
`#116:` Remove deprecated `implprefix` support. Decorate hook implementations using an instance of `HookimplMarker` instead. The deprecation was announced in release `0.7.0`.
`#120:` Remove the deprecated `proc` argument to `call_historic.` Use `result_callback` instead, which has the same behavior. The deprecation was announced in release `0.7.0`.
`#265:` Remove the `_Result.result` property. Use `_Result.get_result()` instead. Note that unlike `result`, `get_result()` raises the exception if the hook raised. The deprecation was announced in release `0.6.0`.
`#267:` Remove official support for `Python 3.4`.
`#272:` Dropped support for `Python 2`. Continue to use pluggy 0.13.x for Python 2 support.
`#308:` Remove official support for Python 3.5.
`#313:` The internal `pluggy.callers`, `pluggy.manager` and `pluggy.hooks` are now explicitly marked private by a `_` prefix (e.g. `pluggy._callers`). Only API exported by the top-level `pluggy` module is considered public.
`#59:` Remove legacy `__multicall__` recursive hook calling system. The deprecation was announced in release `0.5.0.`

The rest of the changes were new features or bug fixes. 

Since must of the deprecations have alternative options, and since must of the deprecations were announced in earlier versions, we can conclude that it is ok to update. 

4. additional research
There is only one open issue in conda forge related to failing builds in OSX
due to http errors
https://github.com/conda-forge/pluggy-feedstock/issues/16

The issue seems to be resolved in the following pull request
https://github.com/conda-forge/pluggy-feedstock/pull/17

5. verify dev_url
6. verify doc_url
7. added pip to the test section
9. verify the test section
10. added wheel to the requirements section
https://github.com/pytest-dev/pluggy/blob/1.0.0/pyproject.toml#L5

11. additional tests

The following command was used to test the `pluggy` package version ``:
`conda build pluggy-feedstock --test`
The test result was as follows:
`All tests passed`

In addition to make sure that `pluggy` can be imported from other packages
the `pytest` package was used and the pinnings for `pluggy` were modified
The following command was used for testing
`conda build pytest-feedstock --test` 
The test result was as follows 
`All tests passed`

also, all of the packages build properly on concourse
https://concourse.build.corp.continuum.io/teams/main/pipelines/mv_pluggy_v1

Based on the research and the test results we can conclude that we should be good to update the `Pluggy` package to version 1.0.0