### PR TITLE
Rebuild pluggy 1.0.0 for python 3.10 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,18 +12,20 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
+  skip: True  # [py<36]
   script: python -m pip install . --no-deps --ignore-installed
 
 requirements:
   host:
     - python 
     - pip
+    - setuptools
     - setuptools_scm
     - wheel
 
   run:
-    - python >=3.6
+    - python
     - importlib_metadata >=0.12  # [py<38]
 
 test:
@@ -31,7 +33,6 @@ test:
     - pluggy
   requires:
     - pip
-    - python <3.10
   command:
     - pip check
 


### PR DESCRIPTION
Requirements:
- https://github.com/pytest-dev/pluggy/blob/1.0.0/pyproject.toml
- https://github.com/pytest-dev/pluggy/blob/1.0.0/setup.cfg

Action:
1. Skip py<36
2. Bump build number to 1
3. Add setuptools
4. Fix python in run
5. Remove python <3.10 from test/requires